### PR TITLE
Remove mandatory args. Fixes issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ placed. This is relative to `gulpfile.js`. E.g. `build/pdf`.
 Additional command line parameters to `pandoc`. 
 E.g. `['--smart', '--css=style.css']`.
 
-The following command line parameters are automatically passed to `pandoc`:
-`['--toc', '--number-sections']`.
-
 # Licenses
 
 Refer to the `LICENSE` file for details.

--- a/index.js
+++ b/index.js
@@ -29,9 +29,6 @@ module.exports = function(opts) {
     var args = opts.args || [];
     var pdfDir = opts.pdfDir;
 
-    var mandatoryArgs = ['--toc', '--number-sections'];
-    args = args.concat(mandatoryArgs);
-
     return through.obj(function (file, enc, cb) {
         var input = file.contents.toString();
         if (file.isNull())  {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pandoc-pdf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "gulp plugin for generating PDFs via pandoc.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I have removed the requirement for mandatory arguments, updated the readme and bumped the version to 0.1.2.
